### PR TITLE
Fix capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ cd JobApplicationTracker
 python -m venv .venv
 # On Windows
 .venv\Scripts\activate
-# On Unix or MacOS
+# On Unix or macOS.
 source .venv/bin/activate
 ```
 


### PR DESCRIPTION
## Summary
- fix capitalization for macOS instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424f95ac8c8329b7577a7ba389f673